### PR TITLE
Fix issue where datetime fields would result in Serialization errors

### DIFF
--- a/splunk_http_event_collector.py
+++ b/splunk_http_event_collector.py
@@ -193,7 +193,7 @@ class http_event_collector:
                 payloadEvent = payload.get('event')
                 payloadEvent = {k:payloadEvent.get(k) for k,v in payloadEvent.items() if v}
                 payload.update({"event":payloadEvent})
-            event.append(json.dumps(payload))
+            event.append(json.dumps(payload, default=str))
         else:
             event.append(str(payload))
 
@@ -220,7 +220,7 @@ class http_event_collector:
                 payloadEvent = payload.get('event')
                 payloadEvent = {k:payloadEvent.get(k) for k,v in payloadEvent.items() if v}
                 payload.update({"event":payloadEvent})
-            payloadString = json.dumps(payload)
+            payloadString = json.dumps(payload, default=str)
 
         else:
             payloadString = str(payload)


### PR DESCRIPTION
datetime objects in the data being converted to JSON would result in serialization errors as the json parser wouldn't know what to do with it.

https://stackoverflow.com/questions/11875770/how-to-overcome-datetime-datetime-not-json-serializable/36142844#36142844

According to the stack overflow there are a few options, but just setting "default=str" is the simplest and most generic.