### PR TITLE
Dont warn on status 400

### DIFF
--- a/splunk_http_event_collector.py
+++ b/splunk_http_event_collector.py
@@ -156,7 +156,10 @@ class http_event_collector:
                 self.log.info("Splunk Server URI is reachable.")
                 hec_reachable = True
             else:
-                if response.status_code in acceptable_status_codes:
+                if response.status_code == 400:
+                    self.log.info("Splunk Server URI is reachable.")
+                    hec_reachable = True
+                elif response.status_code in acceptable_status_codes:
                     self.log.info("Splunk Server URI is reachable.")
                     self.log.warn("Connectivity Check: http_status_code=%s http_message=%s",response.status_code,response.text)
                     hec_reachable = True


### PR DESCRIPTION
Simple fix for issue #14 I raised, to not raise a warning when the status is 400, which indicates:

- No data
- Invalid data format
- Incorrect index
- Data channel is missing
- Invalid data channel
- Event field is required
- Event field cannot be blank
- ACK is disabled
- Error in handling indexed fields

None of which can even apply to an empty payload. Still allows the token to be validated, since thats 401, and enabled which is 403.

https://docs.splunk.com/Documentation/Splunk/8.0.2/Data/TroubleshootHTTPEventCollector#Possible_error_codes