### PR TITLE
Data Channel

### DIFF
--- a/splunk_http_event_collector.py
+++ b/splunk_http_event_collector.py
@@ -144,7 +144,7 @@ class http_event_collector:
         """
 
         self.log.info("Checking HEC Server URI reachability.")
-        headers = {'Authorization':'Splunk '+self.token}
+        headers = {'Authorization':'Splunk '+self.token, 'X-Splunk-Request-Channel':str(uuid.uuid1())}
         payload = dict()
         response = dict() 
         hec_reachable = False
@@ -246,7 +246,7 @@ class http_event_collector:
         while True:
             self.log.debug("Events received on thread. Sending to Splunk.")
             payload = " ".join(self.flushQueue.get())
-            headers = {'Authorization':'Splunk '+self.token}
+            headers = {'Authorization':'Splunk '+self.token, 'X-Splunk-Request-Channel':str(uuid.uuid1())}
             # try to post payload twice then give up and move on
             try:
                 response = self.requests_retry_session().post(self.server_uri, data=payload, headers=headers, verify=self.SSL_verify)


### PR DESCRIPTION
Splunk HEC receivers often need Data Channel defined in more recent releases. 

https://docs.splunk.com/Documentation/Splunk/7.1.2/Data/AboutHECIDXAck#About_channels_and_sending_data
https://community.splunk.com/t5/Archive/HTTP-event-collector-Channel-identifiers-what-do-they-identify/m-p/360197

Adjusted code to add data channel UUID to POST headers. This enables use of HEC with indexers and forwarders configured for `useACK=1`, regardless of 'raw' or 'json' format. 